### PR TITLE
Resolves #78

### DIFF
--- a/assets/schemas/raw-metadata.yaml
+++ b/assets/schemas/raw-metadata.yaml
@@ -141,14 +141,21 @@ properties:
 
   study_PhenoCode:
     description: |
-      Standard, in house trait identifier. Must be in the in ontology (PhenoCode column) or error will be thrown.
+      List of phenotypes in the format of [EOF](https://www.ebi.ac.uk/efo/) codes:
 
-      Checking external inventories for the PMID/preprint link to see if a PhenoCode for exists for this PhenoDesc,
-      else select the best fit from ontology, or for inspiration via related traits.
+      > Experimental Factor Ontology (EFO) provides a systematic description of many experimental
+      > variables available in EBI databases, and for projects such as the GWAS catalog.
 
-      - Ontology: https://docs.google.com/spreadsheets/d/1qghudJelGssaTbe8CDAOHOk7fhpyDAwEKGkOBMqGb3M/
-      - External inventories: https://docs.google.com/spreadsheets/d/1NtSyTscFL6lI5gQ_00bm0reoT6yS2tDB3SHhgM7WwSE/
-    type: "string"
+      EFO has codes for specific traits, diseases and for all the different levels in the
+      hierarchy.
+    type: "array"
+    examples:
+      - ["EFO:0000692"]
+      - ["EFO:0000289", "EFO:0009963"]
+    minItems: 1
+    items:
+      type: "string"
+      pattern: "^EFO:[0-9]{7}$"
 
   study_FilePortal:
     description: |

--- a/lib/Metadata.groovy
+++ b/lib/Metadata.groovy
@@ -21,12 +21,12 @@ class Metadata extends BaseMetadata {
   String path_sumStats = null
   String path_readMe = null
   String path_pdf = null
-  List path_supplementary = []
+  List<String> path_supplementary = []
   String study_Title = null
   String study_PMID = null
   int study_Year = 0
   String study_PhenoDesc = null
-  String study_PhenoCode = null
+  List<String> study_PhenoCode = []
   String study_FilePortal = null
   String study_FileURL = null
   String study_AccessDate = null

--- a/tests/e2e/cases/grch35-all-cols/metadata.yaml
+++ b/tests/e2e/cases/grch35-all-cols/metadata.yaml
@@ -16,9 +16,10 @@ col_SNP: snp
 path_sumStats: sumstats.txt.gz
 
 study_Title: Test study
-study_PMID: https://doi.org/10.1038/s41586-020-03160-0
+study_PMID: "https://doi.org/10.1038/s41586-020-03160-0"
 study_Year: 2021
-study_PhenoCode: Facial attractiveness
+study_PhenoCode:
+  - "EFO:0000692"
 study_PhenoDesc: blabla
 study_AccessDate: 2021-01-21
 study_Use: open

--- a/tests/e2e/cases/grch35-snp-missing/metadata.yaml
+++ b/tests/e2e/cases/grch35-snp-missing/metadata.yaml
@@ -15,9 +15,10 @@ col_SE: se
 path_sumStats: sumstats.txt.gz
 
 study_Title: Test study
-study_PMID: https://doi.org/10.1038/s41586-020-03160-0
+study_PMID: "https://doi.org/10.1038/s41586-020-03160-0"
 study_Year: 2021
-study_PhenoCode: Facial attractiveness
+study_PhenoCode:
+  - "EFO:0000692"
 study_PhenoDesc: blabla
 study_AccessDate: 2021-01-21
 study_Use: open

--- a/tests/e2e/cases/grch38-all-cols/metadata.yaml
+++ b/tests/e2e/cases/grch38-all-cols/metadata.yaml
@@ -16,9 +16,10 @@ col_SNP: snp
 path_sumStats: sumstats.txt.gz
 
 study_Title: Test study
-study_PMID: https://doi.org/10.1038/s41586-020-03160-0
+study_PMID: "https://doi.org/10.1038/s41586-020-03160-0"
 study_Year: 2021
-study_PhenoCode: Facial attractiveness
+study_PhenoCode:
+  - "EFO:0000692"
 study_PhenoDesc: blabla
 study_AccessDate: 2021-01-21
 study_Use: open

--- a/tests/e2e/cases/grch38-chrpos-missing/metadata.yaml
+++ b/tests/e2e/cases/grch38-chrpos-missing/metadata.yaml
@@ -14,9 +14,10 @@ col_SNP: snp
 path_sumStats: sumstats.txt.gz
 
 study_Title: Test study
-study_PMID: https://doi.org/10.1038/s41586-020-03160-0
+study_PMID: "https://doi.org/10.1038/s41586-020-03160-0"
 study_Year: 2021
-study_PhenoCode: Facial attractiveness
+study_PhenoCode:
+  - "EFO:0000692"
 study_PhenoDesc: blabla
 study_AccessDate: 2021-01-21
 study_Use: open

--- a/tests/e2e/cases/grch38-snp-missing/metadata.yaml
+++ b/tests/e2e/cases/grch38-snp-missing/metadata.yaml
@@ -15,9 +15,10 @@ col_SE: se
 path_sumStats: sumstats.txt.gz
 
 study_Title: Test study
-study_PMID: https://doi.org/10.1038/s41586-020-03160-0
+study_PMID: "https://doi.org/10.1038/s41586-020-03160-0"
 study_Year: 2021
-study_PhenoCode: Facial attractiveness
+study_PhenoCode:
+  - "EFO:0000692"
 study_PhenoDesc: blabla
 study_AccessDate: 2021-01-21
 study_Use: open


### PR DESCRIPTION
Changes the metadata schema for the field `study_PhenoCode` to: 

- Be a list of EFO codes
- A minimum of one code required

With the following description (rendered):

-------

 List of phenotypes in the format of [EOF](https://www.ebi.ac.uk/efo/) codes:

 > Experimental Factor Ontology (EFO) provides a systematic description of many experimental
 > variables available in EBI databases, and for projects such as the GWAS catalog.

 EFO has codes for specific traits, diseases and for all the different levels in the
 hierarchy.

-------