### PR TITLE
rewrote the singularity build so that we get an image as output in th…

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,28 +50,42 @@ vi. Start running the cleaning of your own sumstat files!
 
 ```
 
-## Build docker image
-Build the ibp-pipeline-lib-0.1.1.jar file accroding to instructions at: https://github.com/BioPsyk/ibp-pipeline-lib, Then place it inside the docker/ directory in the cleansumstats repository to be accessible by the docker build script. Then build your image,
+## Using images
+
+### Pre-requisites
+
+Docker and singularity has to be installed to create an image executable at a HPC
+- docker-install-instructions(todo)
+- [singularity installation](docs/singularity-installation.md) 
+
+### build images
+
+We have decided to build a docker image first to facilitate how it uses layers to speed up development. From that docker image, it is simple and easy to create a singularity image when deploying the pipeline. The created singulariy image goes to the 'tmp/' folder.
 
 ```bash
+# Build docker image (tied to your system)
 ./scripts/docker-build.sh
+
+# Build singularity image (movable to other systems)
+./scripts/singularity-build.sh
 ```
 
-## Run tests using the docker image
-We have implemented several tests to ensure that the pipeline is doing what we expect. These can be run using the following command,
+### Use docker image
+
+Run tests using the docker image. We have implemented several tests to ensure that the pipeline is doing what we expect. They should all return ok.
 
 ```bash
+# using docker
 ./scripts/docker-run.sh /cleansumstats/tests/run-tests.sh
-```
 
-```bash
-./scripts/docker-build.sh
+# using singularity
+./scripts/singularity-run.sh /cleansumstats/tests/run-tests.sh
 ```
-
 
 ## More documentation
 See [usage docs](docs/usage.md) for all of the available options when running the pipeline.
 See [Output and how to interpret the results](docs/output.md) for the output structure and how to interpret the results.
+See [Developer instructions](docs/developers.md) only for developers
 
 ## Credits
 

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -1,0 +1,8 @@
+# Developer instructions
+
+Here we collect developer specific documentation, which never should be of interest of a user
+
+## Creating the ibp-pipeline-lib .jar file
+Build the ibp-pipeline-lib-x.x.x.jar file accroding to instructions at: https://github.com/BioPsyk/ibp-pipeline-lib, Then place it inside the docker/ directory in the cleansumstats repository to be accessible by the docker build script. To facilitate development and because of the small size of the image, we have decided to store the correct version for this repo in the docker/ directory. If in the future this file becomes too large we might exclude it from the repo.
+
+

--- a/scripts/init-containerization.sh
+++ b/scripts/init-containerization.sh
@@ -22,4 +22,7 @@ mounts=(
 image_tag="ibp-cleansumstats-base:"$(cat "docker/VERSION")
 deploy_image_tag="ibp-cleansumstats:"$(cat "docker/VERSION")
 
+#singularity build
+singularity_image_tag="ibp-cleansumstats-base_version-$(cat "docker/VERSION").simg"
+
 mkdir -p tmp

--- a/scripts/singularity-build.sh
+++ b/scripts/singularity-build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${script_dir}/init-containerization.sh"
+
+exec singularity build tmp/${singularity_image_tag} \
+     docker-daemon:"${image_tag}"
+

--- a/scripts/singularity-run.sh
+++ b/scripts/singularity-run.sh
@@ -14,5 +14,5 @@ exec singularity run \
      --contain \
      --cleanenv \
      ${mount_flags} \
-     docker-daemon:"${image_tag}" \
+     "tmp/${singularity_image_tag}" \
      "$@"

--- a/scripts/singularity-shell.sh
+++ b/scripts/singularity-shell.sh
@@ -14,4 +14,4 @@ exec singularity shell \
      --contain \
      --cleanenv \
      ${mount_flags} \
-     docker-daemon:"${image_tag}"
+     "tmp/${singularity_image_tag}"


### PR DESCRIPTION
Some documentation improvements as well as rewriting the singularity run script to take off from what the singularity build script has generated. Right now the output goes to `tmp/`. If you have any better ideas, let me know?